### PR TITLE
update the recycling bin option

### DIFF
--- a/src/application/application.yaml
+++ b/src/application/application.yaml
@@ -384,7 +384,7 @@ actions:
             -
                 name: Empty trash bin
                 recommend: false
-                code: Powershell -Command "Clear-Recyclebin -Force"
+                code: Powershell -Command "$bin = (New-Object -ComObject Shell.Application).NameSpace(10);$bin.items() | ForEach { Write-Host "Deleting $($_.Name) from Recycle Bin"; Remove-Item $_.Path -Recurse -Force}"
             -
                 name: Enable Reset Base in Dism Component Store
                 recommend: true

--- a/src/application/application.yaml
+++ b/src/application/application.yaml
@@ -384,7 +384,7 @@ actions:
             -
                 name: Empty trash bin
                 recommend: false
-                code: rd /s %systemdrive%\$Recycle.bin
+                code: Powershell -Command "Clear-Recyclebin -Force"
             -
                 name: Enable Reset Base in Dism Component Store
                 recommend: true


### PR DESCRIPTION
Powershell has a module in PS 5.1+ called Clear-Recyclebin that works better than the CMD method - rd /s %systemdrive%\$Recycle.bin

the -Force command cleans all $Recyle.Bin folders for all drives not just the %systemdrive% and the CMD method was missing the /q argument but this is not working in Windows 10. The Powershell method is more reliable. 