### PR TITLE
Replace ampersand in "Movies & TV app" with "and"

### DIFF
--- a/src/application/application.yaml
+++ b/src/application/application.yaml
@@ -2921,7 +2921,7 @@ actions:
                                             parameters:
                                                 packageName: Microsoft.ZuneMusic
                                     -
-                                        name: Movies & TV app
+                                        name: Movies and TV app
                                         docs: https://www.microsoft.com/en-us/p/movies-tv/9wzdncrfj3p2
                                         call:
                                             function: UninstallStoreApp


### PR DESCRIPTION
I was trying out your site and selected 
Bloatware > Provisioned Windows Apps > Zune > Movies & TV app

While running the batch file I saw this in the console: 
`--- Movies`
`'TV' is not recognized as an internal or external command,`
`operable program or batch file.`

This error is caused by the ampersand "&" in the generated line:
`echo --- Movies & TV app`

Ampersands cannot be used in batch files unless you escape them like `^&` because they are special characters  used to separate commands. While this is not the end of the world and nothing bad occurs, it could scare some of your more paranoid users watching the output. I have simply replaced "&" with "and" so this won't occur. 