### PR TITLE
Do not delete temp dirs

### DIFF
--- a/src/application/collections/windows.yaml
+++ b/src/application/collections/windows.yaml
@@ -582,6 +582,7 @@ actions:
                         code: |-
                             del /s /f /q %TEMP%\*
                             del /s /f /q "%WINDIR%\Temp\*"
+                            del /s /f /q %WINDIR%\Prefetch\*
                     -
                         name: Clear main telemetry file
                         recommend: standard

--- a/src/application/collections/windows.yaml
+++ b/src/application/collections/windows.yaml
@@ -580,7 +580,7 @@ actions:
                         name: Clear Windows temp files
                         recommend: standard
                         code: |-
-                            del /s /f /q %TEMP%*
+                            del /s /f /q %TEMP%\*
                             del /s /f /q "%WINDIR%\Temp\*"
                     -
                         name: Clear main telemetry file

--- a/src/application/collections/windows.yaml
+++ b/src/application/collections/windows.yaml
@@ -581,8 +581,7 @@ actions:
                         recommend: standard
                         code: |-
                             del /f /q %localappdata%\Temp\*
-                            rd /s /q "%WINDIR%\Temp"
-                            rd /s /q "%TEMP%"
+                            del /s /q "%WINDIR%\Temp\*"
                     -
                         name: Clear main telemetry file
                         recommend: standard

--- a/src/application/collections/windows.yaml
+++ b/src/application/collections/windows.yaml
@@ -580,8 +580,8 @@ actions:
                         name: Clear Windows temp files
                         recommend: standard
                         code: |-
-                            del /f /q %localappdata%\Temp\*
-                            del /s /q "%WINDIR%\Temp\*"
+                            del /s /f /q %TEMP%*
+                            del /s /f /q "%WINDIR%\Temp\*"
                     -
                         name: Clear main telemetry file
                         recommend: standard


### PR DESCRIPTION
Advantage:
- Some apps break until a new directory (%temp% or C:\Windows\Temp) is created (i.e. dism)

Disadvantage:
- Directories in temp are not deleted

Steps to reproduce:
- Run the "Clear Windows Temp files" code
- Run `dism /online /Disable-Feature /FeatureName:"MicrosoftWindowsPowerShellV2Root" /NoRestart` (other commands may be effected)
- Note an error
- Recreate %temp% and rerun DISM
- No error

Fix:
- Replace `rd /s /q "C:\Windows\Temp"` with `del /s /q "%WINDIR%\Temp\*"`
- Delete `rd /s /q "%TEMP%"` (`del /f /q %localappdata%\Temp\*` seems to work on it's own)

Thank you. Sorry for any errors.