### PR TITLE
win: add shellbags and userassist cleanups

### DIFF
--- a/src/application/collections/windows.yaml
+++ b/src/application/collections/windows.yaml
@@ -680,6 +680,17 @@ actions:
                     )  else (
                         echo No previous Windows installation has been found
                     )
+            -
+                name: Clear ShellBags
+                code: |-
+                    reg delete "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags" /va /f
+                    reg delete "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\BagMRU" /va /f
+                    reg delete "HKCU\Software\Microsoft\Windows\Shell\Bags" /va /f
+                    reg delete "HKCU\Software\Microsoft\Windows\Shell\BagMRU" /va /f
+            -
+                name: Clear UserAssist
+                code: |-
+                    reg delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\UserAssist" /va /f
     -
         category: Disable OS data collection
         children:


### PR DESCRIPTION
ShellBags are used to track the folders that a user has visited, and to remember the settings that were applied to those folders, such as the view mode, sorting options, and window size.