### PR TITLE
win: fix visual studio remote analysis reg entry

### DIFF
--- a/src/application/collections/windows.yaml
+++ b/src/application/collections/windows.yaml
@@ -4438,10 +4438,10 @@ actions:
                             [6]: https://github.com/undergroundwires/privacy.sexy/issues/286 "[BUG]: Disabling IntelliCode data collection crashes VS · Issue #286 · undergroundwires/privacy.sexy | github.com/undergroundwires"
                         code: |-
                             :: Global policy
-                            reg add "HKLM\SOFTWARE\Policies\Microsoft\VisualStudio\IntelliCode" /v "DisableRemoteAnalysis" /d 1 /f
+                            reg add "HKLM\SOFTWARE\Policies\Microsoft\VisualStudio\IntelliCode" /v "DisableRemoteAnalysis" /d 1 /f /t REG_DWORD
                             :: Local policy
-                            reg add "HKCU\SOFTWARE\Microsoft\VSCommon\16.0\IntelliCode" /v "DisableRemoteAnalysis" /d 1 /f
-                            reg add "HKCU\SOFTWARE\Microsoft\VSCommon\17.0\IntelliCode" /v "DisableRemoteAnalysis" /d 1 /f
+                            reg add "HKCU\SOFTWARE\Microsoft\VSCommon\16.0\IntelliCode" /v "DisableRemoteAnalysis" /d 1 /f /t REG_DWORD
+                            reg add "HKCU\SOFTWARE\Microsoft\VSCommon\17.0\IntelliCode" /v "DisableRemoteAnalysis" /d 1 /f /t REG_DWORD
                         revertCode: |-
                             :: Global policy
                             reg delete "HKLM\SOFTWARE\Policies\Microsoft\VisualStudio\IntelliCode" /v "DisableRemoteAnalysis" /f 2>nul


### PR DESCRIPTION
The registry entries for the visual studio DisableRemoteAnalysis keys are incorrect, which can cause a hangup in visual studio. This is a fix for #267.