### PR TITLE
Implement Dark Theme and Theme Switcher

### DIFF
--- a/src/presentation/assets/styles/_colors.scss
+++ b/src/presentation/assets/styles/_colors.scss
@@ -1,45 +1,31 @@
-/*
-    Colors used throughout the application
-    Inspired by the material color system (https://material.io/design/color/the-color-system.html, https://material.io/develop/web/theming/color).
-    Colors are named according to the Vue Design System guidelines (https://github.com/viljamis/vue-design-system/wiki/Naming-of-Things#naming-colors):
-        - Default: The default base color is `color-{name}`.
-        - Darker than default: Shades are named as `color-{name}-dark`, `color-{name}-darker`, or `color-{name}-darkest`.
-        - Lighter than default: Tints are named as `color-{name}-light`, `color-{name}-lighter`, or `color-{name}-lightest`.
-*/
-@use 'sass:color';
+@use './colors/light' as light;
+@use './colors/dark' as dark;
 
-// --- Primary | The color displayed most frequently across screens and components
-$color-primary              : #3a65ab;
-$color-primary-light        : color.adjust($color-primary, $lightness: 30%);
-$color-primary-dark         : color.adjust($color-primary, $lightness: -18%);
-$color-primary-darker       : color.adjust($color-primary, $lightness: -32%);
-$color-primary-darkest      : color.adjust($color-primary, $lightness: -44%);
-// Text/iconography color that is usable on top of primary color
-$color-on-primary           : #e4f1fe;
+$color-primary              : light-dark(light.$color-primary, dark.$color-primary);
+$color-primary-light        : light-dark(light.$color-primary-light, dark.$color-primary-light);
+$color-primary-dark         : light-dark(light.$color-primary-dark, dark.$color-primary-dark);
+$color-primary-darker       : light-dark(light.$color-primary-darker, dark.$color-primary-darker);
+$color-primary-darkest      : light-dark(light.$color-primary-darkest, dark.$color-primary-darkest);
 
-// --- Secondary | Accent color, should be applied sparingly to accent select parts of UI
-$color-secondary            : #00D1AD;
-$color-secondary-light      : color.adjust($color-secondary, $lightness: 48%);
-// Text/iconography color that is usable on top of secondary color
-$color-on-secondary         : #005051;
+$color-on-primary           : light-dark(light.$color-on-primary, dark.$color-on-primary);
 
-// --- Surface | Affect surfaces of components, such as cards, sheets, and menus.
-$color-surface              : #fff;
-// Text/iconography color that is usable on surface
-$color-on-surface           : #4d5156;
+$color-secondary            : light-dark(light.$color-secondary, dark.$color-secondary);
+$color-secondary-light      : light-dark(light.$color-secondary-light, dark.$color-secondary-light);
 
-// Background | Appears behind scrollable content.
-$color-background           : #e6ecf4;
+$color-on-secondary         : light-dark(light.$color-on-secondary, dark.$color-on-secondary);
 
-$color-success  : #4CAF50;
-$color-danger   : #F44336;
-$color-caution  : #FFC107;
+$color-surface              : light-dark(light.$color-surface, dark.$color-surface);
 
-/*
-    Application-specific colors:
-    These are tailored to the specific needs of the application and derived from the above theme colors.
-    Use these colors to ensure consistent styling across components. When adding new colors, reference existing theme colors.
-    This approach maintains a cohesive look and feel and simplifies theme adjustments.
-*/
-$color-scripts-bg: $color-primary-darker;
-$color-highlight: $color-primary;
+$color-on-surface           : light-dark(light.$color-on-surface, dark.$color-on-surface);
+
+$color-background           : light-dark(light.$color-background, dark.$color-background);
+
+$color-success              : light-dark(light.$color-success, dark.$color-success);
+$color-danger               : light-dark(light.$color-danger, dark.$color-danger);
+$color-caution              : light-dark(light.$color-caution, dark.$color-caution);
+
+$color-scripts-bg           : light-dark(light.$color-scripts-bg, dark.$color-scripts-bg);
+$color-highlight            : light-dark(light.$color-highlight, dark.$color-highlight);
+$color-modal-background     : light-dark(light.$color-modal-background, dark.$color-modal-background);
+$color-modal-shadow         : light-dark(light.$color-modal-shadow, dark.$color-modal-shadow);
+$color-code-highlight       : light-dark(light.$color-code-highlight, dark.$color-code-highlight);

--- a/src/presentation/assets/styles/colors/_dark.scss
+++ b/src/presentation/assets/styles/colors/_dark.scss
@@ -1,0 +1,49 @@
+/*
+    Colors used throughout the application
+    Inspired by the material color system (https://material.io/design/color/the-color-system.html, https://material.io/develop/web/theming/color).
+    Colors are named according to the Vue Design System guidelines (https://github.com/viljamis/vue-design-system/wiki/Naming-of-Things#naming-colors):
+        - Default: The default base color is `color-{name}`.
+        - Darker than default: Shades are named as `color-{name}-dark`, `color-{name}-darker`, or `color-{name}-darkest`.
+        - Lighter than default: Tints are named as `color-{name}-light`, `color-{name}-lighter`, or `color-{name}-lightest`.
+*/
+@use 'sass:color';
+
+// --- Primary | The color displayed most frequently across screens and components
+$color-primary              : #3a65ab;
+$color-primary-light        : color.adjust($color-primary, $lightness: 10%);
+$color-primary-dark         : color.adjust($color-primary, $lightness: -18%);
+$color-primary-darker       : color.adjust($color-primary, $lightness: -32%);
+$color-primary-darkest      : color.adjust($color-primary, $lightness: -44%);
+// Text/iconography color that is usable on top of primary color
+$color-on-primary           : #e4f1fe;
+
+// --- Secondary | Accent color, should be applied sparingly to accent select parts of UI
+$color-secondary            : #009E84;
+$color-secondary-light      : color.adjust($color-secondary, $lightness: 48%);
+// Text/iconography color that is usable on top of secondary color
+$color-on-secondary         : #e4f1fe;
+
+// --- Surface | Affect surfaces of components, such as cards, sheets, and menus.
+$color-surface              : #17171f;
+// Text/iconography color that is usable on surface
+$color-on-surface           : #e4f1fe;
+
+// Background | Appears behind scrollable content.
+$color-background           : #0f0f17;
+
+$color-success  : #4CAF50;
+$color-danger   : #F44336;
+$color-caution  : #FFC107;
+
+
+/*
+    Application-specific colors:
+    These are tailored to the specific needs of the application and derived from the above theme colors.
+    Use these colors to ensure consistent styling across components. When adding new colors, reference existing theme colors.
+    This approach maintains a cohesive look and feel and simplifies theme adjustments.
+*/
+$color-scripts-bg: $color-primary-darker;
+$color-highlight: $color-primary;
+$color-modal-background: $color-surface;
+$color-modal-shadow: $color-surface;
+$color-code-highlight: color.adjust($color-secondary, $lightness: -22%);

--- a/src/presentation/assets/styles/colors/_light.scss
+++ b/src/presentation/assets/styles/colors/_light.scss
@@ -1,0 +1,49 @@
+/*
+    Colors used throughout the application
+    Inspired by the material color system (https://material.io/design/color/the-color-system.html, https://material.io/develop/web/theming/color).
+    Colors are named according to the Vue Design System guidelines (https://github.com/viljamis/vue-design-system/wiki/Naming-of-Things#naming-colors):
+        - Default: The default base color is `color-{name}`.
+        - Darker than default: Shades are named as `color-{name}-dark`, `color-{name}-darker`, or `color-{name}-darkest`.
+        - Lighter than default: Tints are named as `color-{name}-light`, `color-{name}-lighter`, or `color-{name}-lightest`.
+*/
+@use 'sass:color';
+
+// --- Primary | The color displayed most frequently across screens and components
+$color-primary              : #3a65ab;
+$color-primary-light        : color.adjust($color-primary, $lightness: 30%);
+$color-primary-dark         : color.adjust($color-primary, $lightness: -18%);
+$color-primary-darker       : color.adjust($color-primary, $lightness: -32%);
+$color-primary-darkest      : color.adjust($color-primary, $lightness: -44%);
+// Text/iconography color that is usable on top of primary color
+$color-on-primary           : #e4f1fe;
+
+// --- Secondary | Accent color, should be applied sparingly to accent select parts of UI
+$color-secondary            : #00D1AD;
+$color-secondary-light      : color.adjust($color-secondary, $lightness: 48%);
+// Text/iconography color that is usable on top of secondary color
+$color-on-secondary         : #005051;
+
+// --- Surface | Affect surfaces of components, such as cards, sheets, and menus.
+$color-surface              : #fff;
+// Text/iconography color that is usable on surface
+$color-on-surface           : #4d5156;
+
+// Background | Appears behind scrollable content.
+$color-background           : #e6ecf4;
+
+$color-success  : #4CAF50;
+$color-danger   : #F44336;
+$color-caution  : #FFC107;
+
+
+/*
+    Application-specific colors:
+    These are tailored to the specific needs of the application and derived from the above theme colors.
+    Use these colors to ensure consistent styling across components. When adding new colors, reference existing theme colors.
+    This approach maintains a cohesive look and feel and simplifies theme adjustments.
+*/
+$color-scripts-bg: $color-primary-darker;
+$color-highlight: $color-primary;
+$color-modal-background: $color-on-surface;
+$color-modal-shadow: $color-on-surface;
+$color-code-highlight: $color-secondary-light;

--- a/src/presentation/components/Code/Ace/AceCodeEditorFactory.ts
+++ b/src/presentation/components/Code/Ace/AceCodeEditorFactory.ts
@@ -1,20 +1,26 @@
+import { ThemeType } from '@/presentation/components/Scripts/Menu/Theme/ThemeType';
 import ace, { AceRange } from './ace-importer';
 import type { CodeEditorFactory, SupportedSyntaxLanguage } from '../CodeEditorFactory';
 
-const CodeEditorTheme = 'xcode';
+const CodeEditorThemeLight = 'xcode';
+const CodeEditorThemeDark = 'twilight';
 
 export const initializeAceEditor: CodeEditorFactory = (options) => {
   const editor = ace.edit(options.editorContainerElementId);
   const mode = getAceModeName(options.language);
   editor.getSession().setMode(`ace/mode/${mode}`);
-  editor.setTheme(`ace/theme/${CodeEditorTheme}`);
+  editor.setTheme(getAceThemePath(ThemeType.System));
   editor.setReadOnly(true);
   editor.setAutoScrollEditorIntoView(true);
   editor.setShowPrintMargin(false); // Hide the vertical line
   editor.getSession().setUseWrapMode(true); // Make code readable on mobile
   hideActiveLineAndCursorUntilInteraction(editor);
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', ({ matches: isDark }) => {
+    editor.setTheme(getAceThemePath(isDark ? ThemeType.Dark : ThemeType.Light));
+  }, { passive: true });
   return {
     setContent: (content) => editor.setValue(content, 1),
+    setTheme: (themeTheme: ThemeType) => editor.setTheme(getAceThemePath(themeTheme)),
     destroy: () => editor.destroy(),
     scrollToLine: (lineNumber) => {
       const column = editor.session.getLine(lineNumber).length;
@@ -87,4 +93,15 @@ function setCursorVisibility(
   //   ✅ .ace_hidden-cursors { opacity: 0; }: Hides cursor when not focused
   //      Pros: Works more automatically
   //      Cons: Provides less control over visibility toggling
+}
+
+function getAceThemePath(themeTheme: ThemeType): string {
+  if (themeTheme === ThemeType.System) {
+    themeTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? ThemeType.Dark : ThemeType.Light;
+  }
+
+  if (themeTheme === ThemeType.Light) return `ace/theme/${CodeEditorThemeLight}`;
+  if (themeTheme === ThemeType.Dark) return `ace/theme/${CodeEditorThemeDark}`;
+
+  throw new Error(`Unsupported theme type: ${themeTheme}`);
 }

--- a/src/presentation/components/Code/Ace/ace-importer.ts
+++ b/src/presentation/components/Code/Ace/ace-importer.ts
@@ -5,7 +5,8 @@ import ace, { Range } from 'ace-builds';
   when built with Vite (`npm run build`).
 */
 
-import 'ace-builds/src-noconflict/theme-xcode';
+import 'ace-builds/src-noconflict/theme-xcode'; // light
+import 'ace-builds/src-noconflict/theme-twilight'; // dark
 import 'ace-builds/src-noconflict/mode-batchfile';
 import 'ace-builds/src-noconflict/mode-sh';
 

--- a/src/presentation/components/Code/CodeEditorFactory.ts
+++ b/src/presentation/components/Code/CodeEditorFactory.ts
@@ -1,3 +1,5 @@
+import type { ThemeType } from '@/presentation/components/Scripts/Menu/Theme/ThemeType';
+
 /**
  * Abstraction layer for code editor functionality.
  * Allows for flexible integration and easy switching of third-party editor implementations.
@@ -16,6 +18,7 @@ export type SupportedSyntaxLanguage = 'batchfile' | 'shellscript';
 export interface CodeEditor {
   destroy(): void;
   setContent(content: string): void;
+  setTheme(themeTheme: ThemeType): void;
   scrollToLine(lineNumber: number): void;
   updateSize(): void;
   applyStyleToLineRange(

--- a/src/presentation/components/Code/TheCodeArea.vue
+++ b/src/presentation/components/Code/TheCodeArea.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import {
-  defineComponent, onUnmounted, onMounted, ref,
+  defineComponent, onUnmounted, onMounted, ref, type PropType, watch,
 } from 'vue';
 import { injectKey } from '@/presentation/injectionSymbols';
 import type { ICodeChangedEvent } from '@/application/Context/State/Code/Event/ICodeChangedEvent';
@@ -25,6 +25,7 @@ import { CodeBuilderFactory } from '@/application/Context/State/Code/Generation/
 import SizeObserver from '@/presentation/components/Shared/SizeObserver.vue';
 import { NonCollapsing } from '@/presentation/components/Scripts/View/Cards/NonCollapsingDirective';
 import type { ProjectDetails } from '@/domain/Project/ProjectDetails';
+import { ThemeType } from '@/presentation/components/Scripts/Menu/Theme/ThemeType';
 import { initializeAceEditor } from './Ace/AceCodeEditorFactory';
 import type { SupportedSyntaxLanguage, CodeEditor, CodeEditorStyleHandle } from './CodeEditorFactory';
 
@@ -35,7 +36,13 @@ export default defineComponent({
   directives: {
     NonCollapsing,
   },
-  setup() {
+  props: {
+    currentTheme: {
+      type: Number as PropType<ThemeType>,
+      required: true,
+    },
+  },
+  setup(props) {
     const { onStateChange, currentState } = injectKey((keys) => keys.useCollectionState);
     const { projectDetails } = injectKey((keys) => keys.useApplication);
     const { events } = injectKey((keys) => keys.useAutoUnsubscribedEvents);
@@ -54,6 +61,9 @@ export default defineComponent({
       onStateChange((newState) => {
         handleNewState(newState);
       }, { immediate: true });
+      watch(() => props.currentTheme, (newTheme) => {
+        editor?.setTheme(newTheme);
+      });
     });
 
     function handleNewState(newState: IReadOnlyCategoryCollectionState) {
@@ -176,7 +186,7 @@ function getDefaultCode(language: ScriptLanguage, project: ProjectDetails): stri
     font-size: $font-size-absolute-small;
     font-family: $font-family-monospace;
     &__highlight {
-      background-color: $color-secondary-light;
+      background-color: $color-code-highlight;
       position: absolute;
     }
   }

--- a/src/presentation/components/DevToolkit/DevToolkit.vue
+++ b/src/presentation/components/DevToolkit/DevToolkit.vue
@@ -83,7 +83,7 @@ $viewport-edge-offset: $spacing-absolute-large; // close to Chromium gutter widt
   top: $viewport-edge-offset;
   right: max(v-bind(scrollbarGutterWidth), $viewport-edge-offset);
 
-  background-color: rgba($color-on-surface, 0.5);
+  background-color: color-mix(in srgb, $color-on-surface, transparent);
   color: $color-on-primary;
   padding: $spacing-absolute-medium;
   z-index: 10000;

--- a/src/presentation/components/Scripts/Menu/TheScriptsMenu.vue
+++ b/src/presentation/components/Scripts/Menu/TheScriptsMenu.vue
@@ -5,11 +5,17 @@
       <TheRevertSelector class="scripts-menu-item" />
     </div>
     <TheOsChanger class="scripts-menu-item" />
-    <TheViewChanger
-      v-if="!isSearching"
-      class="scripts-menu-item"
-      @view-changed="$emit('viewChanged', $event)"
-    />
+    <div class="scripts-menu-item scripts-menu-rows scripts-menu-rows-end">
+      <TheThemeChanger
+        class="scripts-menu-item"
+        @theme-changed="updateTheme($event)"
+      />
+      <TheViewChanger
+        v-if="!isSearching"
+        class="scripts-menu-item"
+        @view-changed="$emit('viewChanged', $event)"
+      />
+    </div>
   </div>
 </template>
 
@@ -19,7 +25,9 @@ import { injectKey } from '@/presentation/injectionSymbols';
 import type { ReadonlyFilterContext } from '@/application/Context/State/Filter/FilterContext';
 import type { IEventSubscription } from '@/infrastructure/Events/IEventSource';
 import TheOsChanger from './TheOsChanger.vue';
+import TheThemeChanger from './Theme/TheThemeChanger.vue';
 import TheViewChanger from './View/TheViewChanger.vue';
+import { ThemeType } from './Theme/ThemeType';
 import { ViewType } from './View/ViewType';
 import TheRecommendationSelector from './Recommendation/TheRecommendationSelector.vue';
 import TheRevertSelector from './Revert/TheRevertSelector.vue';
@@ -28,15 +36,17 @@ export default defineComponent({
   components: {
     TheRecommendationSelector,
     TheOsChanger,
+    TheThemeChanger,
     TheViewChanger,
     TheRevertSelector,
   },
   emits: {
     /* eslint-disable @typescript-eslint/no-unused-vars */
+    themeChanged: (themeType: ThemeType) => true,
     viewChanged: (viewType: ViewType) => true,
     /* eslint-enable @typescript-eslint/no-unused-vars */
   },
-  setup() {
+  setup(_, { emit }) {
     const { onStateChange } = injectKey((keys) => keys.useCollectionState);
     const { events } = injectKey((keys) => keys.useAutoUnsubscribedEvents);
 
@@ -59,8 +69,34 @@ export default defineComponent({
       });
     }
 
+    function updateTheme(themeType: ThemeType) {
+      emit('themeChanged', themeType);
+
+      const meta = document.querySelector('meta[name="color-scheme"]');
+      if (!meta) return;
+
+      switch (themeType) {
+        case ThemeType.System: {
+          meta.setAttribute('content', 'light dark');
+          return;
+        }
+        case ThemeType.Light: {
+          meta.setAttribute('content', 'light');
+          return;
+        }
+        case ThemeType.Dark: {
+          meta.setAttribute('content', 'dark');
+          return;
+        }
+        default: {
+          throw new Error(`Unsupported theme type: ${themeType}`);
+        }
+      }
+    }
+
     return {
       isSearching,
+      updateTheme,
     };
   },
 });
@@ -105,6 +141,9 @@ $responsive-alignment-breakpoint: $media-screen-medium-width;
     flex-direction: column;
     align-items: flex-start;
     row-gap: $spacing-relative-x-small;
+  }
+  .scripts-menu-rows-end {
+    align-items: flex-end;
   }
 }
 </style>

--- a/src/presentation/components/Scripts/Menu/Theme/TheThemeChanger.vue
+++ b/src/presentation/components/Scripts/Menu/Theme/TheThemeChanger.vue
@@ -1,0 +1,63 @@
+<template>
+  <MenuOptionList
+    label="Theme"
+    class="part"
+  >
+    <MenuOptionListItem
+      v-for="theme in themeOptions"
+      :key="theme.type"
+      :label="theme.displayName"
+      :enabled="currentTheme !== theme.type"
+      @click="setTheme(theme.type)"
+    />
+  </MenuOptionList>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import MenuOptionList from '../MenuOptionList.vue';
+import MenuOptionListItem from '../MenuOptionListItem.vue';
+import { ThemeType } from './ThemeType';
+
+const DefaultView = ThemeType.System;
+interface IThemeOption {
+  readonly type: ThemeType;
+  readonly displayName: string;
+}
+const themeOptions: readonly IThemeOption[] = [
+  { type: ThemeType.System, displayName: 'System' },
+  { type: ThemeType.Light, displayName: 'Light' },
+  { type: ThemeType.Dark, displayName: 'Dark' },
+];
+
+export default defineComponent({
+  components: {
+    MenuOptionList,
+    MenuOptionListItem,
+  },
+  emits: {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    themeChanged: (themeType: ThemeType) => true,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  },
+  setup(_, { emit }) {
+    const currentTheme = ref<ThemeType>();
+
+    setTheme(DefaultView);
+
+    function setTheme(theme: ThemeType) {
+      if (currentTheme.value === theme) {
+        throw new Error(`Theme is already "${ThemeType[theme]}"`);
+      }
+      currentTheme.value = theme;
+      emit('themeChanged', currentTheme.value);
+    }
+    return {
+      ThemeType,
+      themeOptions,
+      currentTheme,
+      setTheme,
+    };
+  },
+});
+</script>

--- a/src/presentation/components/Scripts/Menu/Theme/ThemeType.ts
+++ b/src/presentation/components/Scripts/Menu/Theme/ThemeType.ts
@@ -1,0 +1,5 @@
+export enum ThemeType {
+  System = 0,
+  Light = 1,
+  Dark = 2,
+}

--- a/src/presentation/components/Scripts/Menu/View/TheViewChanger.vue
+++ b/src/presentation/components/Scripts/Menu/View/TheViewChanger.vue
@@ -59,9 +59,4 @@ export default defineComponent({
     };
   },
 });
-
-interface IViewOption {
-  readonly type: ViewType;
-  readonly displayName: string;
-}
 </script>

--- a/src/presentation/components/Scripts/TheScriptArea.vue
+++ b/src/presentation/components/Scripts/TheScriptArea.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="script-area">
-    <TheScriptsMenu @view-changed="currentView = $event" />
+    <TheScriptsMenu
+      @theme-changed="currentTheme = $event"
+      @view-changed="currentView = $event"
+    />
     <HorizontalResizeSlider
       class="horizontal-slider"
       first-initial-width="55%"
@@ -11,7 +14,7 @@
         <TheScriptsView :current-view="currentView" />
       </template>
       <template #second>
-        <TheCodeArea />
+        <TheCodeArea :current-theme="currentTheme" />
       </template>
     </HorizontalResizeSlider>
   </div>
@@ -23,6 +26,7 @@ import TheCodeArea from '@/presentation/components/Code/TheCodeArea.vue';
 import TheScriptsView from '@/presentation/components/Scripts/View/TheScriptsView.vue';
 import TheScriptsMenu from '@/presentation/components/Scripts/Menu/TheScriptsMenu.vue';
 import HorizontalResizeSlider from '@/presentation/components/Scripts/Slider/HorizontalResizeSlider.vue';
+import { ThemeType } from '@/presentation/components/Scripts/Menu/Theme/ThemeType';
 import { ViewType } from '@/presentation/components/Scripts/Menu/View/ViewType';
 
 export default defineComponent({
@@ -33,9 +37,10 @@ export default defineComponent({
     HorizontalResizeSlider,
   },
   setup() {
+    const currentTheme = ref(ThemeType.System);
     const currentView = ref(ViewType.Cards);
 
-    return { currentView };
+    return { currentTheme, currentView };
   },
 });
 </script>

--- a/src/presentation/components/Shared/Modal/ModalContent.vue
+++ b/src/presentation/components/Shared/Modal/ModalContent.vue
@@ -101,7 +101,7 @@ $modal-content-offset-upward: $spacing-absolute-x-large;
 
   background-color: $color-surface;
   border-radius: 3px;
-  box-shadow: 0 20px 60px -2px $color-on-surface;
+  box-shadow: 0 20px 60px -2px $color-modal-shadow;
 
   @include scrollable;
 }

--- a/src/presentation/components/Shared/Modal/ModalOverlay.vue
+++ b/src/presentation/components/Shared/Modal/ModalOverlay.vue
@@ -48,7 +48,6 @@ export default defineComponent({
 @use "@/presentation/assets/styles/main" as *;
 
 $modal-overlay-transition-duration: 50ms;
-$modal-overlay-color-background: $color-on-surface;
 
 .modal-overlay-background {
   position: fixed;
@@ -57,7 +56,7 @@ $modal-overlay-color-background: $color-on-surface;
   top: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba($modal-overlay-color-background, 0.3);
+  background: color-mix(in srgb, $color-modal-background, transparent 70%);
   opacity: 1;
 }
 

--- a/src/presentation/components/TheSearchBar.vue
+++ b/src/presentation/components/TheSearchBar.vue
@@ -113,7 +113,7 @@ export default defineComponent({
   color: $color-primary;
   font-size: $font-size-absolute-normal;
   &:focus {
-    color: $color-primary-darker;
+    color: light-dark($color-primary-darker, $color-primary-light);
   }
 }
 

--- a/src/presentation/index.html
+++ b/src/presentation/index.html
@@ -13,6 +13,8 @@
   <meta name="description"
     content="Discover privacy.sexy, the privacy tool to maximize your privacy and security on Windows, macOS, and Linux. Easily use best practices to prevent tracking and make your life secure and private — because privacy is sexy." />
   <meta name="robots" content="index,follow" />
+  <!-- The content of this tag will be altered at runtime -->
+  <meta name="color-scheme" content="light dark" />
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="icon" href="/icon.svg" type="image/svg+xml">
 
@@ -75,7 +77,7 @@
         --splash-color-text: #3a65ab;
         --splash-color-background: #fff;
         --splash-color-spinner-filled: #3a65ab;
-        --splash-color-spinner-empty: rgb(159.4192139738, 183.4541484716, 222.5807860262);
+        --splash-color-spinner-empty: #9fb7df;
         --splash-size-logo: min(80px, calc(100vw/5));
         --splash-size-spinner: calc(var(--splash-size-logo) * 1.75);
         --splash-font-size-large: 21px;
@@ -91,6 +93,13 @@
         --splash-animation-duration-all-fadeout: 1.5s;
         --splash-animation-duration-text-fadeout: 0.4s;
         --splash-animation-delay-long-load-message: 15s;
+
+        @media(prefers-color-scheme: dark) {
+          --splash-color-text: #9fb7df;
+          --splash-color-background: #07070f;
+          --splash-color-spinner-empty: #3a65ab;
+          --splash-color-spinner-filled: #9fb7df;
+        }
       }
 
       .splash-screen,


### PR DESCRIPTION
These changes are a take on implementing a dark theme (and a theme switcher) for #205.

![Screenshot](https://github.com/user-attachments/assets/3d1a1444-aa5c-442e-89fd-20774facee64)

- since the splash screen is not a Vue component, it has some primitive `@media(prefers-color-scheme: dark)` styling
- the `TheThemeChanger` component has been implemented similar to how `TheViewChanger` was implemented
- the colors and the Ace editor's theme now depend on the system's color preference that can be overridden (but not persisted) with the `TheThemeChanger` component
- the colors for the dark theme are mostly derived from the light theme (sometimes just switching front and back colors) or have adjusted lightness

> [!NOTE]
> The way the color variable management looks now might actually be a little sloppy and since I'm not a designer, the dark colors might not be ideal at all, but it's a starting point!